### PR TITLE
Initialize database connection and wire repositories

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,24 +1,53 @@
 package main
 
 import (
+	"context"
+	"database/sql"
+	"time"
+
 	"github.com/Dmitrii-Gor/notification-bot/internal/api"
 	"github.com/Dmitrii-Gor/notification-bot/internal/config"
+	"github.com/Dmitrii-Gor/notification-bot/internal/storage"
 	"github.com/Dmitrii-Gor/notification-bot/pkg/logger"
+	_ "github.com/lib/pq"
 	"go.uber.org/zap"
 )
 
-func main() {
-	logger.InitLogger("dev") // или "prod"
-	defer logger.Sync()
+const httpAddr = ":8080"
 
+func main() {
 	cfg := config.Load()
 
-	gin := api.GinRouter(cfg)
+	logger.InitLogger(cfg.Environment)
+	defer logger.Sync()
 
-	logger.Info("Server starting...", zap.String("addr", ":8080"))
-	logger.Debug("debug log example")
-
-	if err := gin.Run(":8080"); err != nil {
+	db, err := sql.Open("postgres", cfg.DatabaseURL)
+	if err != nil {
+		logger.Error("open database", zap.Error(err))
 		panic(err)
+	}
+
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetConnMaxIdleTime(cfg.DBTimeout)
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.DBTimeout)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		logger.Error("ping database", zap.Error(err))
+		panic(err)
+	}
+
+	defer db.Close()
+
+	userRepo := storage.NewUserRepo(db)
+
+	router := api.GinRouter(cfg, userRepo)
+
+	logger.Info("server starting", zap.String("addr", httpAddr), zap.String("env", cfg.Environment))
+	if err := router.Run(httpAddr); err != nil {
+		logger.Error("server shutdown", zap.Error(err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/Dmitrii-Gor/notification-bot
 go 1.24.0
 
 require (
-	github.com/gin-gonic/gin v1.10.1
-	go.uber.org/zap v1.27.0
+        github.com/gin-gonic/gin v1.10.1
+        github.com/lib/pq v1.10.9
+        go.uber.org/zap v1.27.0
 )
 
 require (

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3,21 +3,27 @@ package api
 import (
 	"github.com/Dmitrii-Gor/notification-bot/internal/api/handlers"
 	"github.com/Dmitrii-Gor/notification-bot/internal/config"
+	"github.com/Dmitrii-Gor/notification-bot/internal/domain"
 	"github.com/gin-gonic/gin"
 )
 
-func GinRouter(cfg *config.Config) *gin.Engine {
+func GinRouter(cfg *config.Config, users domain.UserRepo) *gin.Engine {
 	r := gin.Default()
 
-	emailGroup := r.Group("email")
-
-	auth := handlers.NewAuthHandler()
+	auth := handlers.NewAuthHandler(
+		users,
+		[]byte(cfg.JWT.Secret),
+		cfg.JWT.AccessTTL,
+		cfg.JWT.RefreshTTL,
+		cfg.DBTimeout,
+	)
 
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})
 	})
 
-	emailGroup.POST("/register")
+	emailGroup := r.Group("email")
+	emailGroup.POST("/register", auth.RegisterWithEmail)
 
 	return r
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -8,9 +8,10 @@ var log *zap.Logger
 
 func InitLogger(env string) {
 	var err error
-	if env == "dev" {
+	switch env {
+	case "dev", "development":
 		log, err = zap.NewDevelopment()
-	} else {
+	default:
 		log, err = zap.NewProduction()
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary
- initialize the application logger using the configured environment and open a PostgreSQL connection with pooling in cmd/app
- construct the user repository and feed it alongside configuration into the Gin router while wiring the auth handler
- allow the logger to treat "development" as a development mode and add the pq driver dependency
